### PR TITLE
Correct tagline day of week to Monday

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,7 @@
     <header class="page-header" role="banner">
       <h1 class="project-name">PaPoC 2023</h1>
       <h2>10th Workshop on Principles and Practice of Consistency for Distributed Data</h2>
-      <h2 class="project-tagline">Tuesday, May 8th, 2023 - Organized in conjunction with <a href="https://2023.eurosys.org">EuroSys 2023</a></h2>
+      <h2 class="project-tagline">Monday, May 8th, 2023 - Organized in conjunction with <a href="https://2023.eurosys.org">EuroSys 2023</a></h2>
       <a href="index.html" class="btn">Home</a>
       <a href="cfp.html" class="btn">Call for Papers</a>
       <a href="program.html" class="btn">Program</a>


### PR DESCRIPTION
8th May 2023 is a Monday, Tuesday was not updated from last year.

…at least that's what I suspect what has happened here? Everything says 8th May 2023, so I assume that is correct and the day of week is not. :sweat_smile: